### PR TITLE
[DO NOT MERGE] Test Java 21/25 compatibility via ballerina-library dev workflows

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -9,5 +9,5 @@ jobs:
   call_workflow:
     name: Run Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@dev
     secrets: inherit

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -15,7 +15,7 @@ jobs:
   call_workflow:
     name: Run Central Publish Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/central-publish-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/central-publish-template.yml@dev
     secrets: inherit
     with:
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,7 @@ jobs:
   call_workflow:
     name: Run Release Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-template.yml@dev
     secrets: inherit
     with:
       package-name: copybook

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,5 +7,5 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@dev
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,46 +1,11 @@
 name: PR build
 
 on:
-  pull_request
+  pull_request:
 
 jobs:
-  ubuntu-build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 21.0.3
-      - name: Build with Gradle
-        env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ./gradlew build --stacktrace --scan --console=plain --no-daemon
-      - name: Generate CodeCov Report
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: ballerina-platform/copybook-tools
-
-  windows-build:
-
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 21.0.3
-      - name: Build with Gradle
-        env:
-          packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-          JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
-        run: ./gradlew.bat build -Pdisable=invalid_permission --stacktrace --scan --console=plain --no-daemon
+  call_workflow:
+    name: Run PR Build Workflow
+    if: ${{ github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    secrets: inherit

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -29,7 +29,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -40,10 +40,12 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build.gradle
+++ b/build.gradle
@@ -66,9 +66,18 @@ subprojects {
     }
 }
 
-tasks.register('build') {
-    dependsOn(":copybook-cli:build")
-    dependsOn(":copybook-tool:build")
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn(":copybook-cli:build")
+        dependsOn(":copybook-tool:build")
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn(":copybook-cli:build")
+        dependsOn(":copybook-tool:build")
+
+    }
 }
 
 def moduleVersion = project.version.replace("-SNAPSHOT", "")

--- a/copybook-cli/build.gradle
+++ b/copybook-cli/build.gradle
@@ -102,7 +102,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
     }

--- a/copybook-tool/BalTool.toml
+++ b/copybook-tool/BalTool.toml
@@ -2,7 +2,7 @@
 id = "copybook"
 
 [[dependency]]
-path = "build/libs/copybook-cli-1.1.0.jar"
+path = "build/libs/copybook-cli-1.1.1-SNAPSHOT.jar"
 
 [[dependency]]
 path = "build/libs/antlr4-runtime-4.13.1.jar"

--- a/copybook-tool/build.gradle
+++ b/copybook-tool/build.gradle
@@ -18,6 +18,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -67,8 +74,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml BalTool.toml"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,18 +4,18 @@ org.gradle.caching=true
 group=io.ballerina
 version=1.1.1-SNAPSHOT
 
-spotbugsPluginVersion=6.0.18
-releasePluginVersion=2.8.0
+spotbugsPluginVersion=6.5.1
+releasePluginVersion=3.1.0
 checkstylePluginVersion=10.12.0
 downloadPluginVersion=5.4.0
 ballerinaLangVersion=2201.11.0
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=4.0.0
 
 picocliVersion=4.7.4
 testngVersion=7.7.0
 slf4jVersion=2.0.9
 antlrVersion=4.13.1
-jacocoVersion=0.8.10
+jacocoVersion=0.8.14
 
 # Ballerinax
 copybookParserVersion=1.1.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,7 +37,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'copybook-tools'
@@ -48,9 +48,9 @@ include('copybook-tool')
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
**DO NOT MERGE — this PR exists only to run CI against the `ballerina-library` `dev` branch workflows for Java 21/25 compatibility testing.**

Combines the gradle upgrade from PR 1 with pointing this repo's `ballerina-library` reusable workflows at `dev` instead of `main`. Close (don't merge) once the `dev` branch changes land upstream in `ballerina-library`'s `main` — PR 1 is the one that should land here.

## Test plan
- [ ] CI passes on the `dev` ballerina-library workflows for Java 21 and Java 25
